### PR TITLE
naming suggestions

### DIFF
--- a/Code/GraphMol/Atropisomers.cpp
+++ b/Code/GraphMol/Atropisomers.cpp
@@ -26,8 +26,9 @@
 constexpr double REALLY_SMALL_BOND_LEN = 0.0000001;
 
 namespace RDKit {
+namespace Atropisomers {
 
-bool GetAtropisomerAtomsAndBonds(const Bond *bond, Atom *atoms[2],
+bool getAtropisomerAtomsAndBonds(const Bond *bond, Atom *atoms[2],
                                  std::vector<Bond *> bonds[2],
                                  const ROMol &mol) {
   PRECONDITION(bond, "no bond");
@@ -218,7 +219,7 @@ bool DetectAtropisomerChiralityOneBond(Bond *bond, ROMol &mol,
   std::vector<Bond *> bonds[2];  // one vector for each end - each one
                                  // should end up with 1 ro 2 entries
 
-  if (!GetAtropisomerAtomsAndBonds(bond, atoms, bonds, mol)) {
+  if (!getAtropisomerAtomsAndBonds(bond, atoms, bonds, mol)) {
     return false;  // not an atropisomer
   }
 
@@ -395,7 +396,7 @@ void cleanupAtropisomerStereoGroups(ROMol &mol) {
   mol.setStereoGroups(std::move(newsgs));
 }
 
-void DetectAtropisomerChirality(ROMol &mol, const Conformer *conf) {
+void detectAtropisomerChirality(ROMol &mol, const Conformer *conf) {
   PRECONDITION(conf, "no conformer");
   PRECONDITION(&(conf->getOwningMol()) == &mol,
                "conformer does not belong to molecule");
@@ -482,7 +483,7 @@ bool WedgeBondFromAtropisomerOneBond2d(Bond *bond, const ROMol &mol,
   std::vector<Bond *> bonds[2];  // one vector for each end - each one
                                  // should end up with 1 ro 2 entries
 
-  if (!GetAtropisomerAtomsAndBonds(bond, atoms, bonds, mol)) {
+  if (!getAtropisomerAtomsAndBonds(bond, atoms, bonds, mol)) {
     return false;  // not an atropisomer
   }
 
@@ -659,7 +660,7 @@ bool WedgeBondFromAtropisomerOneBond3d(Bond *bond, const ROMol &mol,
   std::vector<Bond *> bonds[2];  // one vector for each end - each one
                                  // should end up with 1 ro 2 entries
 
-  if (!GetAtropisomerAtomsAndBonds(bond, atoms, bonds, mol)) {
+  if (!getAtropisomerAtomsAndBonds(bond, atoms, bonds, mol)) {
     return false;  // not an atropisomer
   }
 
@@ -794,7 +795,7 @@ bool WedgeBondFromAtropisomerOneBond3d(Bond *bond, const ROMol &mol,
   return true;
 }
 
-void WedgeBondsFromAtropisomers(const ROMol &mol, const Conformer *conf,
+void wedgeBondsFromAtropisomers(const ROMol &mol, const Conformer *conf,
                                 const INT_MAP_INT &wedgeBonds) {
   PRECONDITION(conf, "no conformer");
   PRECONDITION(&(conf->getOwningMol()) == &mol,
@@ -832,5 +833,5 @@ bool doesMolHaveAtropisomers(const ROMol &mol) {
   }
   return false;
 }
-
+}  // namespace Atropisomers
 }  // namespace RDKit

--- a/Code/GraphMol/Atropisomers.cpp
+++ b/Code/GraphMol/Atropisomers.cpp
@@ -404,7 +404,7 @@ void detectAtropisomerChirality(ROMol &mol, const Conformer *conf) {
   std::set<Bond *> bondsToTry;
 
   for (auto bond : mol.bonds()) {
-    if (bond->canHaveDirection() &&
+    if (canHaveDirection(*bond) &&
         (bond->getBondDir() == Bond::BondDir::BEGINDASH ||
          bond->getBondDir() == Bond::BondDir::BEGINWEDGE)) {
       for (const auto &nbrBond : mol.atomBonds(bond->getBeginAtom())) {
@@ -550,7 +550,7 @@ bool WedgeBondFromAtropisomerOneBond2d(Bond *bond, const ROMol &mol,
 
       if ((bondDir == Bond::BEGINWEDGE || bondDir == Bond::BEGINDASH) &&
           bonds[whichEnd][whichBond]->getBeginAtom() == atoms[whichEnd] &&
-          bond->canHaveDirection()) {
+          canHaveDirection(*bond)) {
         useBondsAtEnd[whichEnd].push_back(whichBond);
         foundBondDir = true;
       }
@@ -584,7 +584,7 @@ bool WedgeBondFromAtropisomerOneBond2d(Bond *bond, const ROMol &mol,
          ++whichBond) {
       auto bondToTry = bonds[whichEnd][whichBond];
 
-      if (!bondToTry->canHaveDirection() ||
+      if (!canHaveDirection(*bondToTry) ||
           wedgeBonds.find(bondToTry->getIdx()) != wedgeBonds.end()) {
         continue;  // must be a single OR aromatic bond and not already spoken
                    // for by a chiral center
@@ -689,7 +689,7 @@ bool WedgeBondFromAtropisomerOneBond3d(Bond *bond, const ROMol &mol,
       // main bond
 
       if ((bondDir == Bond::BEGINWEDGE || bondDir == Bond::BEGINDASH) &&
-          bond->getBeginAtom() == atoms[whichEnd] && bond->canHaveDirection()) {
+          bond->getBeginAtom() == atoms[whichEnd] && canHaveDirection(*bond)) {
         useBonds.push_back(bond);
       }
     }
@@ -723,7 +723,7 @@ bool WedgeBondFromAtropisomerOneBond3d(Bond *bond, const ROMol &mol,
       // cannot use a bond that is not single, nor if it is already slated
       // to be used for a chiral center
 
-      if (!bondToTry->canHaveDirection() ||
+      if (!canHaveDirection(*bondToTry) ||
           wedgeBonds.find(bond->getIdx()) != wedgeBonds.end()) {
         continue;  // must be a single bond and not already spoken
                    // for by a chiral center

--- a/Code/GraphMol/Atropisomers.h
+++ b/Code/GraphMol/Atropisomers.h
@@ -17,19 +17,21 @@
 #include <stdexcept>
 
 namespace RDKit {
-RDKIT_GRAPHMOL_EXPORT void DetectAtropisomerChirality(ROMol &mol,
+namespace Atropisomers {
+RDKIT_GRAPHMOL_EXPORT void detectAtropisomerChirality(ROMol &mol,
                                                       const Conformer *conf);
-RDKIT_GRAPHMOL_EXPORT void WedgeBondsFromAtropisomers(
+RDKIT_GRAPHMOL_EXPORT void wedgeBondsFromAtropisomers(
     const ROMol &mol, const Conformer *conf, const INT_MAP_INT &wedgeBonds);
 
 RDKIT_GRAPHMOL_EXPORT bool doesMolHaveAtropisomers(const ROMol &mol);
 
-RDKIT_GRAPHMOL_EXPORT bool GetAtropisomerAtomsAndBonds(
+RDKIT_GRAPHMOL_EXPORT bool getAtropisomerAtomsAndBonds(
     const Bond *bond, Atom *atoms[2], std::vector<Bond *> bonds[2],
     const ROMol &mol);
 
 RDKIT_GRAPHMOL_EXPORT void getAllAtomIdsForStereoGroup(
     const ROMol &mol, const StereoGroup &group,
     std::vector<unsigned int> &atomIds);
+}  // namespace Atropisomers
 }  // namespace RDKit
 #endif

--- a/Code/GraphMol/Bond.cpp
+++ b/Code/GraphMol/Bond.cpp
@@ -325,6 +325,7 @@ bool Bond::invertChirality() {
   }
   return false;
 }
+
 };  // namespace RDKit
 
 std::ostream &operator<<(std::ostream &target, const RDKit::Bond &bond) {

--- a/Code/GraphMol/Bond.h
+++ b/Code/GraphMol/Bond.h
@@ -97,9 +97,9 @@ class RDKIT_GRAPHMOL_EXPORT Bond : public RDProps {
     STEREOANY,       // intentionally unspecified
     // -- Put any true specifications about this point so
     // that we can do comparisons like if(bond->getStereo()>Bond::STEREOANY)
-    STEREOZ,     // Z double bond
-    STEREOE,     // E double bond
-    STEREOCIS,   // cis double bond
+    STEREOZ,         // Z double bond
+    STEREOE,         // E double bond
+    STEREOCIS,       // cis double bond
     STEREOTRANS,     // trans double bond
     STEREOATROPCW,   //  atropisomer clockwise rotation
     STEREOATROPCCW,  //  atropisomer counter clockwise rotation
@@ -317,17 +317,6 @@ class RDKIT_GRAPHMOL_EXPORT Bond : public RDProps {
   //! returns our direction
   BondDir getBondDir() const { return static_cast<BondDir>(d_dirTag); }
 
-  bool canHaveDirection() const {
-    auto bondType = getBondType();
-    return (bondType == Bond::SINGLE || bondType == Bond::AROMATIC);
-  }
-
-  bool canSetDoubleBondStereo() const {
-    auto bondType = getBondType();
-    return (bondType == Bond::SINGLE || bondType == Bond::AROMATIC ||
-            isDative());
-  }
-
   //! sets our stereo code
   /*!
       STEREONONE, STEREOANY, STEREOE and STEREOZ can be set without
@@ -379,12 +368,6 @@ class RDKIT_GRAPHMOL_EXPORT Bond : public RDProps {
     return *dp_stereoAtoms;
   }
 
-  bool isDative() const {
-    auto bt = this->getBondType();
-    return bt == Bond::BondType::DATIVE || bt == Bond::BondType::DATIVEL ||
-           bt == Bond::BondType::DATIVER || bt == Bond::BondType::DATIVEONE;
-  }
-
   //! calculates any of our lazy \c properties
   /*!
     <b>Notes:</b>
@@ -409,6 +392,23 @@ class RDKIT_GRAPHMOL_EXPORT Bond : public RDProps {
 
   void initBond();
 };
+
+inline bool isDative(const Bond &bond) {
+  auto bt = bond.getBondType();
+  return bt == Bond::BondType::DATIVE || bt == Bond::BondType::DATIVEL ||
+         bt == Bond::BondType::DATIVER || bt == Bond::BondType::DATIVEONE;
+}
+
+inline bool canSetDoubleBondStereo(const Bond &bond) {
+  auto bondType = bond.getBondType();
+  return (bondType == Bond::SINGLE || bondType == Bond::AROMATIC ||
+          isDative(bond));
+}
+
+inline bool canHaveDirection(const Bond &bond) {
+  auto bondType = bond.getBondType();
+  return (bondType == Bond::SINGLE || bondType == Bond::AROMATIC);
+}
 
 //! returns twice the \c bondType
 //! (e.g. SINGLE->2, AROMATIC->3, etc.)

--- a/Code/GraphMol/CIPLabeler/configs/AtropisomerBond.cpp
+++ b/Code/GraphMol/CIPLabeler/configs/AtropisomerBond.cpp
@@ -30,7 +30,8 @@ AtropisomerBond::AtropisomerBond(const CIPMol &mol, Bond *bond, Atom *startAtom,
   std::vector<Bond *> bonds[2];  // one vector for each end - each one
                                  // should end up with 1 ro 2 entries
 
-  if (!GetAtropisomerAtomsAndBonds(bond, atoms, bonds, bond->getOwningMol())) {
+  if (!Atropisomers::getAtropisomerAtomsAndBonds(bond, atoms, bonds,
+                                                 bond->getOwningMol())) {
     return;  // not an atropisomer
   }
   auto atom1 = mol.getAtom(bonds[0][0]->getOtherAtomIdx(atoms[0]->getIdx()));

--- a/Code/GraphMol/Canon.cpp
+++ b/Code/GraphMol/Canon.cpp
@@ -119,7 +119,7 @@ bool checkBondsInSameBranch(MolStack &molStack, Bond *dblBnd, Bond *dirBnd) {
 void switchBondDir(Bond *bond) {
   PRECONDITION(bond, "bad bond");
   PRECONDITION(bond->getBondType() == Bond::SINGLE || bond->getIsAromatic() ||
-                   bond->isDative(),
+                   isDative(*bond),
                "bad bond type");
   switch (bond->getBondDir()) {
     case Bond::ENDUPRIGHT:
@@ -193,7 +193,7 @@ void canonicalizeDoubleBond(Bond *dblBond, UINT_VECT &bondVisitOrders,
                                auto atom, auto &firstNeighborBond,
                                auto &secondNeighborBond, auto &dirSet) {
     for (const auto bond : mol.atomBonds(atom)) {
-      if (bond == dblBond || !bond->canSetDoubleBondStereo()) {
+      if (bond == dblBond || !canSetDoubleBondStereo(*bond)) {
         continue;
       }
 
@@ -910,10 +910,10 @@ void clearBondDirs(ROMol &mol, Bond *refBond, const Atom *fromAtom,
   bool nbrPossible = false, adjusted = false;
   while (beg != end) {
     Bond *oBond = mol[*beg];
-    // std::cerr<<"  >>"<<oBond->getIdx()<<" "<<canHaveDirection(oBond)<<"
+    // std::cerr<<"  >>"<<oBond->getIdx()<<" "<<canHaveDirection(*oBond)<<"
     // "<<bondDirCounts[oBond->getIdx()]<<"-"<<bondDirCounts[refBond->getIdx()]<<"
     // "<<atomDirCounts[oBond->getBeginAtomIdx()]<<"-"<<atomDirCounts[oBond->getEndAtomIdx()]<<std::endl;
-    if (oBond != refBond && oBond->canHaveDirection()) {
+    if (oBond != refBond && canHaveDirection(*oBond)) {
       nbrPossible = true;
       if ((bondDirCounts[oBond->getIdx()] >=
            bondDirCounts[refBond->getIdx()]) &&
@@ -967,7 +967,7 @@ void removeRedundantBondDirSpecs(ROMol &mol, MolStack &molStack,
       const Atom *canonBeginAtom = mol.getAtomWithIdx(msI.number);
       const Atom *canonEndAtom =
           mol.getAtomWithIdx(tBond->getOtherAtomIdx(msI.number));
-      if (tBond->canHaveDirection() && bondDirCounts[tBond->getIdx()] >= 1) {
+      if (canHaveDirection(*tBond) && bondDirCounts[tBond->getIdx()] >= 1) {
         // start by finding the double bond that sets tBond's direction:
         const Atom *dblBondAtom = nullptr;
         ROMol::OEDGE_ITER beg, end;

--- a/Code/GraphMol/Chirality.cpp
+++ b/Code/GraphMol/Chirality.cpp
@@ -2581,7 +2581,7 @@ void GetMolFileBondStereoInfo(const Bond *bond, const INT_MAP_INT &wedgeBonds,
   dirCode = 0;
   reverse = false;
   Bond::BondDir dir = Bond::NONE;
-  if (bond->canHaveDirection()) {
+  if (canHaveDirection(*bond)) {
     // single bond stereo chemistry
     dir = Chirality::detail::determineBondWedgeState(bond, wedgeBonds, conf);
     dirCode = BondGetDirCode(dir);

--- a/Code/GraphMol/FileParsers/MolFileParser.cpp
+++ b/Code/GraphMol/FileParsers/MolFileParser.cpp
@@ -3248,7 +3248,7 @@ void finishMolProcessing(RWMol *res, bool chiralityPossible, bool sanitize,
     }
   }
 
-  DetectAtropisomerChirality(*res, &conf);
+  Atropisomers::detectAtropisomerChirality(*res, &conf);
 
   // now that atom stereochem has been perceived, the wedging
   // information is no longer needed, so we clear

--- a/Code/GraphMol/FileParsers/MolFileWriter.cpp
+++ b/Code/GraphMol/FileParsers/MolFileWriter.cpp
@@ -1075,7 +1075,7 @@ void appendEnhancedStereoGroups(std::string &res, const RWMol &tmol) {
       res += " ATOMS=(";
 
       std::vector<unsigned int> atomIds;
-      getAllAtomIdsForStereoGroup(tmol, group, atomIds);
+      Atropisomers::getAllAtomIdsForStereoGroup(tmol, group, atomIds);
 
       res += std::to_string(atomIds.size());
       for (auto &&atom : atomIds) {
@@ -1126,7 +1126,7 @@ std::string getV3000CTAB(const ROMol &tmol, int confId) {
 
     INT_MAP_INT wedgeBonds = Chirality::pickBondsToWedge(tmol);
     if (conf) {
-      WedgeBondsFromAtropisomers(tmol, conf, wedgeBonds);
+      Atropisomers::wedgeBondsFromAtropisomers(tmol, conf, wedgeBonds);
     }
 
     for (ROMol::ConstBondIterator bondIt = tmol.beginBonds();
@@ -1269,7 +1269,7 @@ std::string outputMolToMolBlock(const RWMol &tmol, int confId,
     INT_MAP_INT wedgeBonds = Chirality::pickBondsToWedge(tmol);
 
     if (conf) {
-      WedgeBondsFromAtropisomers(tmol, conf, wedgeBonds);
+      Atropisomers::wedgeBondsFromAtropisomers(tmol, conf, wedgeBonds);
     }
 
     for (ROMol::ConstBondIterator bondIt = tmol.beginBonds();

--- a/Code/GraphMol/FileParsers/testAtropisomers.cpp
+++ b/Code/GraphMol/FileParsers/testAtropisomers.cpp
@@ -224,7 +224,6 @@ class MolAtropTest {
       for (auto sdfTest : sdfTests) {
         BOOST_LOG(rdInfoLog) << "Test: " << sdfTest.fileName << std::endl;
 
-        printf("Test\n\n %s\n\n", sdfTest.fileName.c_str());
         testMolFiles(&sdfTest);
       }
     }
@@ -235,6 +234,7 @@ int main(int argc, char *argv[]) {
   (void)argc;
   (void)argv;
   RDLog::InitLogs();
+  boost::logging::enable_logs("rdApp.info");
   BOOST_LOG(rdInfoLog) << " ---- Running with POSIX locale ----- " << std::endl;
 
   RDKit::Chirality::setPerceive3DChiralExplicitOnly(true);

--- a/Code/GraphMol/FindRings.cpp
+++ b/Code/GraphMol/FindRings.cpp
@@ -878,7 +878,7 @@ int findSSSR(const ROMol &mol, VECT_INT_VECT &res, bool includeDativeBonds) {
   while (firstB != lastB) {
     const Bond *bond = mol[*firstB];
     if (bond->getBondType() == Bond::ZERO ||
-        (!includeDativeBonds && bond->isDative())) {
+        (!includeDativeBonds && isDative(*bond))) {
       activeBonds[bond->getIdx()] = 0;
     }
     ++firstB;
@@ -896,7 +896,7 @@ int findSSSR(const ROMol &mol, VECT_INT_VECT &res, bool includeDativeBonds) {
     atomDegreesWithZeroOrderBonds[i] = deg;
     for (const auto bond : mol.atomBonds(atom)) {
       if (bond->getBondType() == Bond::ZERO ||
-          (!includeDativeBonds && bond->isDative())) {
+          (!includeDativeBonds && isDative(*bond))) {
         atomDegrees[i]--;
       }
     }

--- a/Code/GraphMol/MarvinParse/MarvinParser.cpp
+++ b/Code/GraphMol/MarvinParse/MarvinParser.cpp
@@ -610,8 +610,8 @@ class MarvinCMLReader {
       }
 
       if (conf || conf3d) {
-        RDKit::DetectAtropisomerChirality(*mol,
-                                          conf != nullptr ? conf : conf3d);
+        Atropisomers::detectAtropisomerChirality(
+            *mol, conf != nullptr ? conf : conf3d);
       }
 
       ClearSingleBondDirFlags(*mol);

--- a/Code/GraphMol/MarvinParse/MarvinWriter.cpp
+++ b/Code/GraphMol/MarvinParse/MarvinWriter.cpp
@@ -517,9 +517,9 @@ class MarvinCMLWriter {
       INT_MAP_INT wedgeBonds = Chirality::pickBondsToWedge(*mol);
 
       if (conf) {
-        WedgeBondsFromAtropisomers(*mol, conf, wedgeBonds);
+        Atropisomers::wedgeBondsFromAtropisomers(*mol, conf, wedgeBonds);
       } else if (conf3d) {
-        WedgeBondsFromAtropisomers(*mol, conf3d, wedgeBonds);
+        Atropisomers::wedgeBondsFromAtropisomers(*mol, conf3d, wedgeBonds);
       }
 
       for (auto bond : mol->bonds()) {
@@ -604,7 +604,7 @@ class MarvinCMLWriter {
         }
 
         std::vector<unsigned int> atomIds;
-        getAllAtomIdsForStereoGroup(*mol, group, atomIds);
+        Atropisomers::getAllAtomIdsForStereoGroup(*mol, group, atomIds);
 
         for (auto atomId : atomIds) {
           marvinMol->atoms[atomId]->mrvStereoGroup = stereoGroupType;

--- a/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
+++ b/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
@@ -1562,7 +1562,7 @@ getSortedStereoGroupsAndIndices(const ROMol &mol,
   for (const auto &sg : groups) {
     // const auto atomIndexes = getSortedMappedIndexes(sg.getAtoms(), revOrder);
     std::vector<unsigned int> atomIds;
-    getAllAtomIdsForStereoGroup(mol, sg, atomIds);
+    Atropisomers::getAllAtomIdsForStereoGroup(mol, sg, atomIds);
     const auto newAtomIndexes = getSortedMappedIndexes(atomIds, revOrder);
     if (!newAtomIndexes.empty()) {
       sortingGroups.emplace_back(sg, newAtomIndexes);
@@ -2371,7 +2371,8 @@ std::string getCXExtensions(const ROMol &mol, std::uint32_t flags) {
     INT_MAP_INT wedgeBonds = Chirality::pickBondsToWedge(mol);
 
     if (mol.getNumConformers()) {
-      WedgeBondsFromAtropisomers(mol, &mol.getConformer(), wedgeBonds);
+      Atropisomers::wedgeBondsFromAtropisomers(mol, &mol.getConformer(),
+                                               wedgeBonds);
     }
 
     bool includeCoords = flags & SmilesWrite::CXSmilesFields::CX_COORDS &&
@@ -2390,7 +2391,8 @@ std::string getCXExtensions(const ROMol &mol, std::uint32_t flags) {
     INT_MAP_INT wedgeBonds;
 
     if (mol.getNumConformers()) {
-      WedgeBondsFromAtropisomers(mol, &mol.getConformer(), wedgeBonds);
+      Atropisomers::wedgeBondsFromAtropisomers(mol, &mol.getConformer(),
+                                               wedgeBonds);
     }
 
     bool includeCoords = flags & SmilesWrite::CXSmilesFields::CX_COORDS &&

--- a/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
+++ b/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
@@ -1106,11 +1106,11 @@ bool parse_wedged_bonds(Iterator &first, Iterator last, RDKit::RWMol &mol,
       }
       bond->setProp(common_properties::_MolFileBondCfg, cfg);
       bond->setBondDir(state);
-      if (cfg == 2 && bond->canHaveDirection()) {
+      if (cfg == 2 && canHaveDirection(*bond)) {
         bond->getBeginAtom()->setChiralTag(Atom::ChiralType::CHI_UNSPECIFIED);
         mol.setProp(detail::_needsDetectBondStereo, 1);
       }
-      if ((cfg == 1 || cfg == 3) && bond->canHaveDirection()) {
+      if ((cfg == 1 || cfg == 3) && canHaveDirection(*bond)) {
         mol.setProp(detail::_needsDetectAtomStereo, 1);
       }
     }
@@ -2060,7 +2060,7 @@ std::string get_bond_config_block(const ROMol &mol,
     const auto bond = mol.getBondWithIdx(idx);
     unsigned int wedgeStartAtomIdx = bond->getBeginAtomIdx();
 
-    if (!bond->canHaveDirection()) {
+    if (!canHaveDirection(*bond)) {
       continue;
     }
     // when figuring out what to output for the bond, favor the wedge state:

--- a/Code/GraphMol/SmilesParse/SmilesParse.cpp
+++ b/Code/GraphMol/SmilesParse/SmilesParse.cpp
@@ -461,7 +461,7 @@ RWMol *SmilesToMol(const std::string &smiles,
   }
   if (conf || conf3d) {
     try {
-      RDKit::DetectAtropisomerChirality(*res, conf ? conf : conf3d);
+      Atropisomers::detectAtropisomerChirality(*res, conf ? conf : conf3d);
     } catch (...) {
       delete res;
       throw;

--- a/Code/GraphMol/SmilesParse/SmilesWrite.cpp
+++ b/Code/GraphMol/SmilesParse/SmilesWrite.cpp
@@ -686,7 +686,7 @@ std::string MolToCXSmiles(const ROMol &romol, const SmilesWriteParams &params,
     RDKit::Chirality::reapplyMolBlockWedging(trwmol);
   } else if (restoreBondDirs == RestoreBondDirOptionClear) {
     for (auto bond : trwmol.bonds()) {
-      if (!bond->canHaveDirection()) {
+      if (!canHaveDirection(*bond)) {
         continue;
       }
       if (bond->getBondDir() != Bond::BondDir::NONE) {

--- a/Code/GraphMol/WedgeBonds.cpp
+++ b/Code/GraphMol/WedgeBonds.cpp
@@ -517,7 +517,7 @@ void reapplyMolBlockWedging(ROMol &mol) {
     int bond_dir = -1;
     if (b->getPropIfPresent<int>(common_properties::_MolFileBondStereo,
                                  bond_dir)) {
-      if (b->canHaveDirection()) {
+      if (canHaveDirection(*b)) {
         if (bond_dir == 1) {
           b->setBondDir(Bond::BEGINWEDGE);
         } else if (bond_dir == 6) {
@@ -538,12 +538,12 @@ void reapplyMolBlockWedging(ROMol &mol) {
     b->getPropIfPresent<int>(common_properties::_MolFileBondCfg, cfg);
     switch (cfg) {
       case 1:
-        if (b->canHaveDirection()) {
+        if (canHaveDirection(*b)) {
           b->setBondDir(Bond::BEGINWEDGE);
         }
         break;
       case 2:
-        if (b->canHaveDirection()) {
+        if (canHaveDirection(*b)) {
           b->setBondDir(Bond::UNKNOWN);
         } else if (b->getBondType() == Bond::DOUBLE) {
           b->setBondDir(Bond::EITHERDOUBLE);
@@ -551,7 +551,7 @@ void reapplyMolBlockWedging(ROMol &mol) {
         }
         break;
       case 3:
-        if (b->canHaveDirection()) {
+        if (canHaveDirection(*b)) {
           b->setBondDir(Bond::BEGINDASH);
         }
         break;

--- a/Code/GraphMol/new_canon.cpp
+++ b/Code/GraphMol/new_canon.cpp
@@ -438,8 +438,8 @@ bondholder makeBondHolder(const Bond *bond, unsigned int otherIdx,
       std::vector<Bond *> atropBonds[2];  // one vector for each end - each one
                                           // should end up with 1 ro 2 entries
 
-      CHECK_INVARIANT(GetAtropisomerAtomsAndBonds(bond, atropAtoms, atropBonds,
-                                                  bond->getOwningMol()),
+      CHECK_INVARIANT(Atropisomers::getAtropisomerAtomsAndBonds(
+                          bond, atropAtoms, atropBonds, bond->getOwningMol()),
                       "Could not find atropisomer controlling atoms")
 
       res.controllingAtoms[0] =


### PR DESCRIPTION
Nothing major here, just getting the naming more "standard", moving the new functionality to an `Atropisomers` namespace, and pulling some of the functions added to Bond out of that class - we try to keep the API of the core types as minimal as possible... sometimes we forget, of course but it's worth trying.