### PR TITLE
A few suggestions on MacroMol PR

### DIFF
--- a/Code/GraphMol/CMakeLists.txt
+++ b/Code/GraphMol/CMakeLists.txt
@@ -42,7 +42,6 @@ rdkit_headers(Atom.h
         Rings.h
         ROMol.h
         RWMol.h
-        SCSRMol.h
         MACROMol.h
         SanitException.h
         SubstanceGroup.h

--- a/Code/GraphMol/FileParsers/CMakeLists.txt
+++ b/Code/GraphMol/FileParsers/CMakeLists.txt
@@ -59,7 +59,6 @@ rdkit_headers(CDXMLParser.h
     FileParsers.h
     FileParserUtils.h
     SCSRUtils.h
-    SCSRMolFileWriter.h
     MACROMolUtils.h
     MolFileStereochem.h
     FileWriters.h

--- a/Code/GraphMol/FileParsers/MACROMolUtils.cpp
+++ b/Code/GraphMol/FileParsers/MACROMolUtils.cpp
@@ -133,7 +133,7 @@ class MolFromMACROMolConverter {
 
     // copy the atoms of the sgroup into the new molecule
 
-    auto templatePtr = macroMol->atomIdxToTemplatePtr(atomIdx);
+    auto templatePtr = macroMol->getTemplate(atomIdx);
 
     if (newConf) {
       newConf->resize(newConf->getNumAtoms() + templatePtr->getNumAtoms());
@@ -220,7 +220,7 @@ class MolFromMACROMolConverter {
 
       std::set<const MACROMolTemplate *> templatesInUse;
       for (unsigned int atomIdx = 0 ; atomIdx != macroMol->getNumAtoms(); ++atomIdx) {
-         auto templatePtr = macroMol->atomIdxToTemplatePtr(atomIdx);
+         auto templatePtr = macroMol->getTemplate(atomIdx);
          if (templatePtr != nullptr && !templatesInUse.contains(templatePtr)) {
           templatesInUse.insert(templatePtr);
          }
@@ -334,7 +334,7 @@ class MolFromMACROMolConverter {
         atom->getPropIfPresent(common_properties::molAtomSeqId, seqId);
         atom->getPropIfPresent(common_properties::molAtomSeqName, seqName);
 
-        auto templateMol= macroMol->atomIdxToTemplatePtr(atomIdx);
+        auto templateMol= macroMol->getTemplate(atomIdx);
         std::vector<std::string> templateNames;
         std::string templateNameToUse;
 
@@ -794,7 +794,7 @@ bool isTemplateMatchAHit(
 }
 
 std::unique_ptr<RDKit::MACROMol> MolToMACROMol(
-    const ROMol &mol, RDKit::MACROMolTemplateLib &templates,
+    const ROMol &mol, const RDKit::MACROMolTemplateLib &templates,
     MolToMACROParams molToMACROMolParams) {
   auto res = std::unique_ptr<MACROMol>(new MACROMol());
 
@@ -803,7 +803,7 @@ std::unique_ptr<RDKit::MACROMol> MolToMACROMol(
 }
 
 void MolToMACROMol(MACROMol *res,
-    const ROMol &mol, RDKit::MACROMolTemplateLib &templates,
+    const ROMol &mol, const RDKit::MACROMolTemplateLib &templates,
     MolToMACROParams molToMACROMolParams) {
 
   Conformer *conf = nullptr;
@@ -893,7 +893,7 @@ void MolToMACROMol(MACROMol *res,
 
       if (!templateCopied) {
         // add the template to the MACROMol
-        std::unique_ptr<const MACROMolTemplate> tempTemplate(
+        std::unique_ptr<MACROMolTemplate> tempTemplate(
             new MACROMolTemplate(*templateMol));
         res->addTemplate(tempTemplate);
         templateCopied = true;

--- a/Code/GraphMol/FileParsers/MACROMolUtils.cpp
+++ b/Code/GraphMol/FileParsers/MACROMolUtils.cpp
@@ -133,16 +133,14 @@ class MolFromMACROMolConverter {
 
     // copy the atoms of the sgroup into the new molecule
 
+    auto templatePtr = macroMol->atomIdxToTemplatePtr(atomIdx);
+
     if (newConf) {
-      newConf->resize(
-          newConf->getNumAtoms() +
-          macroMol->atomIdxToTemplatePtr(atomIdx)->getNumAtoms());
+      newConf->resize(newConf->getNumAtoms() + templatePtr->getNumAtoms());
     }
 
     for (auto templateAtomIdx : sgroup.getAtoms()) {
-      auto templateAtom =
-          macroMol->atomIdxToTemplatePtr(atomIdx)->getAtomWithIdx(
-              templateAtomIdx);
+      auto templateAtom = templatePtr->getAtomWithIdx(templateAtomIdx);
       auto newAtom = new Atom(*templateAtom);
 
       mol->addAtom(newAtom, true, true);
@@ -154,9 +152,8 @@ class MolFromMACROMolConverter {
       if (newConf) {
         newConf->setAtomPos(
             newAtom->getIdx(),
-            coordOffset + macroMol->atomIdxToTemplatePtr(atomIdx)
-                              ->getConformer()
-                              .getAtomPos(templateAtomIdx));
+            coordOffset +
+                templatePtr->getConformer().getAtomPos(templateAtomIdx));
       }
     }
   }
@@ -820,10 +817,8 @@ void MolToMACROMol(MACROMol *res,
 
   std::map<unsigned int, unsigned int> atomMap;
   std::map<BondConnectionDef, std::string> bondConnectionMap;
-  for (unsigned int templateIndex = 0;
-       templateIndex < templates.getNumTemplates(); ++templateIndex) {
-    auto templateMol = templates.getTemplate(templateIndex);
-    templateMol->updatePropertyCache(false);
+  for (const auto &templatePtr : templates) {
+    auto templateMol = templatePtr.get();
     std::vector<std::string> templateNames;
 
     std::string templateAtomClass;
@@ -898,7 +893,7 @@ void MolToMACROMol(MACROMol *res,
 
       if (!templateCopied) {
         // add the template to the MACROMol
-        std::unique_ptr<MACROMolTemplate> tempTemplate(
+        std::unique_ptr<const MACROMolTemplate> tempTemplate(
             new MACROMolTemplate(*templateMol));
         res->addTemplate(tempTemplate);
         templateCopied = true;

--- a/Code/GraphMol/FileParsers/MACROMolUtils.h
+++ b/Code/GraphMol/FileParsers/MACROMolUtils.h
@@ -65,11 +65,11 @@ RDKIT_FILEPARSERS_EXPORT void MACROMolToSCSRMolFile(
     const RDKit::MolWriterParams &params, int confId);
 
 RDKIT_FILEPARSERS_EXPORT std::unique_ptr<RDKit::MACROMol> MolToMACROMol(
-    const ROMol &mol, RDKit::MACROMolTemplateLib &templates,
+    const ROMol &mol, const RDKit::MACROMolTemplateLib &templates,
     MolToMACROParams molToMACROMolParams = MolToMACROParams());
-    
+
 RDKIT_FILEPARSERS_EXPORT void MolToMACROMol(MACROMol *res,
-    const ROMol &mol, RDKit::MACROMolTemplateLib &templates,
+    const ROMol &mol, const RDKit::MACROMolTemplateLib &templates,
     MolToMACROParams molToMACROMolParams = MolToMACROParams());
 
 }  // namespace RDKit

--- a/Code/GraphMol/FileParsers/SCSRUtils.cpp
+++ b/Code/GraphMol/FileParsers/SCSRUtils.cpp
@@ -418,7 +418,6 @@ std::unique_ptr<RDKit::MACROMol> MACROMolFromSCSRDataStream(
 
       std::unique_ptr<MACROMolTemplate> newTemplate(new MACROMolTemplate(
           templateMol, templateClass, templateNames, otherTokens));
-      newTemplate->updatePropertyCache(false);
 
       res->addTemplate(newTemplate);
       templateMol = nullptr;
@@ -1004,9 +1003,9 @@ std::string MACROMolToSCSRMolBlock(MACROMol &macroMol,
   // now write out all of the templates
 
   res += "M  V30 BEGIN TEMPLATE\n";
-  for (unsigned int templateId = 0; templateId < macroMol.getNumTemplates();
-       ++templateId) {
-    auto macroMolTemplate = macroMol.getTemplate(templateId);
+  unsigned int templateId = 0;
+  for (const auto &templatePtr : *macroMol.getTemplateLibrary()) {
+    auto macroMolTemplate = templatePtr.get();
     std::string templateClass;
     std::vector<std::string> templateNames;
     std::string natReplace = "";
@@ -1103,6 +1102,7 @@ std::string MACROMolToSCSRMolBlock(MACROMol &macroMol,
     prepareMol(*molToUse, localParams, aromaticBonds);
     res += FileParserUtils::getV3000CTAB(*molToUse, aromaticBonds, confId,
                                          localParams.precision);
+    ++templateId;
   }
 
   res += "M  V30 END TEMPLATE\n";

--- a/Code/GraphMol/FileParsers/SCSRUtils.cpp
+++ b/Code/GraphMol/FileParsers/SCSRUtils.cpp
@@ -418,6 +418,9 @@ std::unique_ptr<RDKit::MACROMol> MACROMolFromSCSRDataStream(
 
       std::unique_ptr<MACROMolTemplate> newTemplate(new MACROMolTemplate(
           templateMol, templateClass, templateNames, otherTokens));
+      // update the property cache now, while the template is still mutable, so
+      // downstream consumers (which see it as const) can substructure-match it
+      newTemplate->updatePropertyCache(false);
 
       res->addTemplate(newTemplate);
       templateMol = nullptr;
@@ -450,7 +453,7 @@ std::unique_ptr<RDKit::MACROMol> MACROMolFromSCSRDataStream(
   for (unsigned int atomIdx = 0; atomIdx < atomCount; ++atomIdx) {
     auto atom = res->getAtomWithIdx(atomIdx);
 
-    auto templateMol = res->atomIdxToTemplatePtr(atomIdx);
+    auto templateMol = res->getTemplate(atomIdx);
     if (templateMol == nullptr) {
       continue;  // no template for this atom - regular atom
     }
@@ -501,7 +504,7 @@ std::unique_ptr<RDKit::MACROMol> MACROMolFromSCSRDataStream(
   // involved in an h-bond. fix the template to have the standard hbond
   // attachment names (Hb1, Hb2, Hb3)
 
-  std::map<MACROMolTemplate *, SCSRHbondData> baseTemplateHbondData;
+  std::map<const MACROMolTemplate *, SCSRHbondData> baseTemplateHbondData;
 
   for (auto bond : res->bonds()) {
     if (bond->hasProp(common_properties::_MolFileBondAttachPt1) ||
@@ -524,7 +527,7 @@ std::unique_ptr<RDKit::MACROMol> MACROMolFromSCSRDataStream(
       auto otherAtomId =
           (atomToCheck == atom1) ? atom2->getIdx() : atom1->getIdx();
 
-      auto templatePtr = res->atomIdxToTemplatePtr(atomToCheck->getIdx());
+      auto templatePtr = res->getTemplate(atomToCheck->getIdx());
       if (templatePtr == nullptr) {
         continue;  // not a template atom
       }
@@ -625,8 +628,6 @@ std::unique_ptr<RDKit::MACROMol> MACROMolFromSCSRDataStream(
            {HydrogenBondConnection(7, true),
             HydrogenBondConnection(9, false)}}};
 
-      templateMol->updatePropertyCache(false);
-
       for (const auto &querySmi : hbondQueries) {
         RDKit::SubstructMatchParameters params;
         auto match = SubstructMatch(*templateMol, *querySmi.dp_mol, params);
@@ -650,10 +651,14 @@ std::unique_ptr<RDKit::MACROMol> MACROMolFromSCSRDataStream(
     }
 
     if (sapsChanged) {
-      templateMol->getMainSgroup()->clearAttachPoints();
+      // need to update the SAPs on the template, typically not allowed since the template is const,
+      // but we are still in parsing and know that no one else has access to the template yet, so it
+      // is safe to modify it in place
+      auto *mutableTemplate = const_cast<MACROMolTemplate *>(templateMol);
+      mutableTemplate->getMainSgroup()->clearAttachPoints();
       for (auto &newSap : newSaps) {
-        templateMol->getMainSgroup()->addAttachPoint(newSap.aIdx, newSap.lvIdx,
-                                                     newSap.id);
+        mutableTemplate->getMainSgroup()->addAttachPoint(newSap.aIdx,
+                                                         newSap.lvIdx, newSap.id);
       }
     }
   }
@@ -667,8 +672,8 @@ std::unique_ptr<RDKit::MACROMol> MACROMolFromSCSRDataStream(
     auto atom1Idx = atom1->getIdx();
     auto atom2Idx = atom2->getIdx();
 
-    auto templatePtr1 = res->atomIdxToTemplatePtr(atom1Idx);
-    auto templatePtr2 = res->atomIdxToTemplatePtr(atom2Idx);
+    auto templatePtr1 = res->getTemplate(atom1Idx);
+    auto templatePtr2 = res->getTemplate(atom2Idx);
 
     if (bond->getBondType() == Bond::BondType::HYDROGEN &&
         templatePtr1 != nullptr && templatePtr2 != nullptr &&
@@ -695,7 +700,7 @@ std::unique_ptr<RDKit::MACROMol> MACROMolFromSCSRDataStream(
         auto otherAtomId =
             (atomToCheck == atom1) ? atom2->getIdx() : atom1->getIdx();
 
-        if (res->atomIdxToTemplatePtr(atomToCheck->getIdx()) == nullptr) {
+        if (res->getTemplate(atomToCheck->getIdx()) == nullptr) {
           continue;  // not a template atom
         }
 
@@ -866,14 +871,14 @@ std::string MACROMolToSCSRMolBlock(MACROMol &macroMol,
 
   // for each BASE tempate, the list of
   // h-bond connection point names to fix
-  std::map<MACROMolTemplate *, std::vector<std::string>> templateHbondConnections;
+  std::map<const MACROMolTemplate *, std::vector<std::string>> templateHbondConnections;
 
   // for each BASE tempate, the list of
   // h-bond connection point name BASES to fix
   // for sets of hbond connections like Hb1, Hb2, Hb3, this would be "Hb"
   // THis allows us to change all such connections even when only one or two
   // are used in the main mol
-  std::map<MACROMolTemplate *, std::vector<std::string>> templateHbondConnectionBases;
+  std::map<const MACROMolTemplate *, std::vector<std::string>> templateHbondConnectionBases;
 
   std::vector<std::pair<unsigned int, unsigned int>>
       hBonds;  // the bonds to keep (re-add).
@@ -929,7 +934,7 @@ std::string MACROMolToSCSRMolBlock(MACROMol &macroMol,
 
         // mark which templates need to be fixed so the attach points are "Hb"
 
-        auto templatePtr = macroMol.atomIdxToTemplatePtr(atomToCheck->getIdx());
+        auto templatePtr = macroMol.getTemplate(atomToCheck->getIdx());
         if (!templateHbondConnections.contains(templatePtr)) {
           templateHbondConnections[templatePtr] = std::vector<std::string>();
         }
@@ -1042,8 +1047,9 @@ std::string MACROMolToSCSRMolBlock(MACROMol &macroMol,
     // copy template mol so we can modify it for output without affecting the
     // original, if needed
 
-    RWMol *molToUse = macroMolTemplate;
-    std::unique_ptr<RWMol> tMol;
+    // work on a copy: prepareMol mutates the mol, and the template is const
+    std::unique_ptr<RWMol> tMol(new RWMol(*macroMolTemplate));
+    RWMol *molToUse = tMol.get();
 
     // check to see if the template need to be modified for hbonds
     // connections. if we are keeping them, they are changed to "Hb" if not
@@ -1051,9 +1057,6 @@ std::string MACROMolToSCSRMolBlock(MACROMol &macroMol,
 
     if (templateHbondConnections.contains(macroMolTemplate) ||
         templateHbondConnectionBases.contains(macroMolTemplate)) {
-      tMol.reset(new RWMol(*macroMolTemplate));
-      molToUse = tMol.get();
-
       auto &hbondConnections = templateHbondConnections[macroMolTemplate];
       auto &hbondConnectionBases = templateHbondConnectionBases[macroMolTemplate];
       auto &sgroups = RDKit::getSubstanceGroups(*(tMol.get()));

--- a/Code/GraphMol/FileParsers/macromols_catch.cpp
+++ b/Code/GraphMol/FileParsers/macromols_catch.cpp
@@ -326,7 +326,7 @@ class ScsrMolTest {
     CHECK(outMacroMol != nullptr);
     CHECK(outMacroMol->getNumAtoms() == macroMol->getNumAtoms());
     CHECK(outMacroMol->getNumBonds() == macroMol->getNumBonds());
-    CHECK(outMacroMol->getNumTemplates() == macroMol->getNumTemplates());
+    CHECK(outMacroMol->size() == macroMol->size());
 
     MACROMolToSCSRMolFile(*(outMacroMol.get()), fOutName2);
 

--- a/Code/GraphMol/MACROMol.cpp
+++ b/Code/GraphMol/MACROMol.cpp
@@ -78,27 +78,33 @@ MACROMolTemplate::MACROMolTemplate(std::unique_ptr<RWMol> &mol,
   MACROMolTemplate::init(className, templateNames, templateAttrs);
 }
 
- RDKit::SubstanceGroup *MACROMolTemplate::getMainSgroup() const {
-    
-    std::call_once(d_mainSgroupIdxOnceFlag, [this]() {
-      std::string className = "";
-      std::vector<std::string> templateNames;
-      if (!getPropIfPresent(RDKit::common_properties::molAtomClass,
-                                  className) ||
-          !getPropIfPresent(RDKit::common_properties::templateNames,
-                                  templateNames)) {
-        std::ostringstream errout;
-        errout << "Template molecule is missing required properties: "
-               << RDKit::common_properties::molAtomClass << " and/or "
-               << RDKit::common_properties::templateNames;
-        throw RDKit::FileParseException(errout.str());
-      }
-   
+void MACROMolTemplate::initMainSgroupIdx() const {
+  std::call_once(d_mainSgroupIdxOnceFlag, [this]() {
+    std::string className = "";
+    std::vector<std::string> templateNames;
+    if (!getPropIfPresent(RDKit::common_properties::molAtomClass, className) ||
+        !getPropIfPresent(RDKit::common_properties::templateNames,
+                          templateNames)) {
+      std::ostringstream errout;
+      errout << "Template molecule is missing required properties: "
+             << RDKit::common_properties::molAtomClass << " and/or "
+             << RDKit::common_properties::templateNames;
+      throw RDKit::FileParseException(errout.str());
+    }
 
-      findMainSgroupForTemplate(className, templateNames[0]);
-    });
-    return &RDKit::getSubstanceGroups(*this)[d_mainSgroupIdx];
-  }
+    findMainSgroupForTemplate(className, templateNames[0]);
+  });
+}
+
+RDKit::SubstanceGroup *MACROMolTemplate::getMainSgroup() {
+  initMainSgroupIdx();
+  return &RDKit::getSubstanceGroups(*this)[d_mainSgroupIdx];
+}
+
+const RDKit::SubstanceGroup *MACROMolTemplate::getMainSgroup() const {
+  initMainSgroupIdx();
+  return &RDKit::getSubstanceGroups(*this)[d_mainSgroupIdx];
+}
 
 
 
@@ -131,7 +137,7 @@ void RDKit::MACROMol::addMacroBond(unsigned int fromAtomIdx,
   }
 }
 
-MACROMolTemplate *RDKit::MACROMol::atomIdxToTemplatePtr(
+const MACROMolTemplate *RDKit::MACROMol::getTemplate(
     unsigned int atomIdx) const {
   const auto atom = this->getAtomWithIdx(atomIdx);
 
@@ -174,11 +180,13 @@ void MACROMolTemplateLib::addTemplate(std::unique_ptr<MACROMolTemplate> &templat
   }
 
   void MACROMolTemplateLib::copyTemplateLib(const MACROMolTemplateLib &libToCopy){
-    this->clearTemplateLib();
+    // clear any existing templates in this library
+    d_templates.clear();
+    d_keyToIndex.clear();
 
     for (auto &templateToCopy : libToCopy) {
       // make a copy of the template
-      auto templateCopy = std::unique_ptr<const MACROMolTemplate>(new MACROMolTemplate(*(templateToCopy.get())));
+      auto templateCopy = std::unique_ptr<MACROMolTemplate>(new MACROMolTemplate(*(templateToCopy.get())));
       this->addTemplate(templateCopy);
     }
 

--- a/Code/GraphMol/MACROMol.cpp
+++ b/Code/GraphMol/MACROMol.cpp
@@ -49,6 +49,7 @@ void RDKit::MACROMolTemplate::init(std::string className,
 
   }
   d_mainSgroupIdx = UINT_MAX;
+  this->updatePropertyCache(false);
 }
 
 MACROMolTemplate::MACROMolTemplate(std::unique_ptr<RWMol> &mol,
@@ -77,7 +78,7 @@ MACROMolTemplate::MACROMolTemplate(std::unique_ptr<RWMol> &mol,
   MACROMolTemplate::init(className, templateNames, templateAttrs);
 }
 
- RDKit::SubstanceGroup *MACROMolTemplate::getMainSgroup() {
+ RDKit::SubstanceGroup *MACROMolTemplate::getMainSgroup() const {
     
     std::call_once(d_mainSgroupIdxOnceFlag, [this]() {
       std::string className = "";
@@ -108,7 +109,6 @@ unsigned int RDKit::MACROMol::addMacroAtom(std::string className,
 
   atom->setProp(common_properties::dummyLabel, templateName);
   atom->setProp(common_properties::molAtomClass, className);
-  d_atomIdxToTemplatePtrIsStale = true;
   return this->addAtom(atom, false, true);
 }
 
@@ -131,51 +131,26 @@ void RDKit::MACROMol::addMacroBond(unsigned int fromAtomIdx,
   }
 }
 
- MACROMolTemplate *RDKit::MACROMol::atomIdxToTemplatePtr(unsigned int atomIdx) const {
-  if (d_atomIdxToTemplatePtrIsStale) {
-    // rebuild the map
-    d_atomIdxToTemplatePtr.clear();
+MACROMolTemplate *RDKit::MACROMol::atomIdxToTemplatePtr(
+    unsigned int atomIdx) const {
+  const auto atom = this->getAtomWithIdx(atomIdx);
 
-    for (auto atom : this->atoms()) {
-      std::string atomClass;
-      std::string dummyLabel = "";
-
-      d_atomIdxToTemplatePtr[atom->getIdx()] = nullptr;
-
-      if (!atom->getPropIfPresent(common_properties::dummyLabel, dummyLabel) ||
-          dummyLabel == "" ||
-          !atom->getPropIfPresent(common_properties::molAtomClass, atomClass) ||
-          atomClass == "") {
-        continue;
-      }
-
-      // first look in the local temmplates, if any
-      bool foundTemplate = false;
-      if (d_templateLibrary.libContains(atomClass, dummyLabel)) {
-        d_atomIdxToTemplatePtr[atom->getIdx()]  = this->d_templateLibrary.getTemplate(atomClass, dummyLabel);
-        foundTemplate = true;
-      } else {
-        // try all the external libs
-
-        for (const auto extLib :  d_externalTemplateLibs) {
-          if( extLib->libContains(atomClass, dummyLabel)) {
-            d_atomIdxToTemplatePtr[atom->getIdx()]  = extLib->getTemplate(atomClass, dummyLabel);
-            foundTemplate = true;
-            break;
-          }
-        }
-      }
-      if (!foundTemplate) {
-          std::ostringstream errout;
-          errout << "Template not found for atom " << dummyLabel;
-          throw RDKit::FileParseException(errout.str());
-      }
-    }
-
-
-    d_atomIdxToTemplatePtrIsStale = false;
+  std::string atomClass;
+  std::string dummyLabel = "";
+  if (!atom->getPropIfPresent(common_properties::dummyLabel, dummyLabel) ||
+      dummyLabel == "" ||
+      !atom->getPropIfPresent(common_properties::molAtomClass, atomClass) ||
+      atomClass == "") {
+    return nullptr;  // ordinary atom, not a macro atom
   }
-  return d_atomIdxToTemplatePtr[atomIdx];
+
+  auto templatePtr = d_templateLibrary.find(atomClass, dummyLabel);
+  if (templatePtr == nullptr) {
+    std::ostringstream errout;
+    errout << "Template not found for atom " << dummyLabel;
+    throw RDKit::FileParseException(errout.str());
+  }
+  return templatePtr;
 }
 
 void MACROMolTemplateLib::addTemplate(std::unique_ptr<MACROMolTemplate> &templateMolToAdd) {
@@ -198,23 +173,13 @@ void MACROMolTemplateLib::addTemplate(std::unique_ptr<MACROMolTemplate> &templat
     }
   }
 
-  void MACROMolTemplateLib::addTemplateLib(MACROMolTemplateLib &libToAdd) {
-    for (auto &libTemplate : libToAdd) {
-      addTemplate(libTemplate);
-    }
-  }
-
   void MACROMolTemplateLib::copyTemplateLib(const MACROMolTemplateLib &libToCopy){
     this->clearTemplateLib();
 
-  
-    
     for (auto &templateToCopy : libToCopy) {
       // make a copy of the template
-
-      auto templateCopy = std::unique_ptr<MACROMolTemplate>(new MACROMolTemplate(*(templateToCopy.get())));
+      auto templateCopy = std::unique_ptr<const MACROMolTemplate>(new MACROMolTemplate(*(templateToCopy.get())));
       this->addTemplate(templateCopy);
-
     }
 
   }

--- a/Code/GraphMol/MACROMol.h
+++ b/Code/GraphMol/MACROMol.h
@@ -22,13 +22,6 @@
 namespace RDKit {
 
 class RDKIT_GRAPHMOL_EXPORT MACROMolTemplate : public RDKit::RWMol {
- private:
-  void init(std::string className,
-            std::vector<std::string> templateNames,
-            std::vector<std::pair<std::string,std::string>> templateAttrs);
-
-  void findMainSgroupForTemplate(std::string className,
-                                 std::string templateName) const;
 
  public:
   MACROMolTemplate(std::unique_ptr<RWMol> &mol, std::string className,
@@ -46,9 +39,17 @@ class RDKIT_GRAPHMOL_EXPORT MACROMolTemplate : public RDKit::RWMol {
   MACROMolTemplate &operator=(const MACROMolTemplate &) = delete; 
   ~MACROMolTemplate() {}
 
-  RDKit::SubstanceGroup *getMainSgroup() const;
+  RDKit::SubstanceGroup *getMainSgroup();
+  const RDKit::SubstanceGroup *getMainSgroup() const;
 
  private:
+  void init(std::string className,
+            std::vector<std::string> templateNames,
+            std::vector<std::pair<std::string,std::string>> templateAttrs);
+
+  void findMainSgroupForTemplate(std::string className,
+                                 std::string templateName) const;
+  void initMainSgroupIdx() const;
   mutable unsigned int d_mainSgroupIdx;
   mutable std::once_flag d_mainSgroupIdxOnceFlag;
 };
@@ -57,8 +58,9 @@ class RDKIT_GRAPHMOL_EXPORT MACROMolTemplate : public RDKit::RWMol {
 class RDKIT_GRAPHMOL_EXPORT MACROMolTemplateLib {
 
   private:
-    // All templates in the library are owned by the library and cannot be changed
-    std::vector<std::unique_ptr<const MACROMolTemplate>> d_templates;
+    // All templates in the library are owned by the library. Consumers get
+    // const access; the library mutates them only during construction.
+    std::vector<std::unique_ptr<MACROMolTemplate>> d_templates;
 
     //! Key is (monomer_class, symbol)
     using MACROMolTemplateKey = std::pair<std::string, std::string>;
@@ -82,19 +84,15 @@ class RDKIT_GRAPHMOL_EXPORT MACROMolTemplateLib {
     MACROMolTemplateLib &operator=(const MACROMolTemplateLib &) = delete;  
     ~MACROMolTemplateLib() {}
 
-    std::vector<std::unique_ptr<const MACROMolTemplate>>::const_iterator begin() const {
+    std::vector<std::unique_ptr<MACROMolTemplate>>::const_iterator begin() const {
       return d_templates.begin();
     }
-    std::vector<std::unique_ptr<const MACROMolTemplate>>::const_iterator end() const {
+    std::vector<std::unique_ptr<MACROMolTemplate>>::const_iterator end() const {
       return d_templates.end();
     }
 
-    void addTemplate(std::unique_ptr<const MACROMolTemplate> &templateMol);
+    void addTemplate(std::unique_ptr<MACROMolTemplate> &templateMol);
     void copyTemplateLib(const MACROMolTemplateLib &libToCopy);
-    void clearTemplateLib(){
-        d_templates.clear();
-        d_keyToIndex.clear();
-    }
 
     unsigned int size() const {
       return d_templates.size(); 
@@ -112,7 +110,7 @@ class RDKIT_GRAPHMOL_EXPORT MACROMolTemplateLib {
       return d_keyToIndex.contains({templateClass, templateName});
     }
 
-    bool doesLibHaveCoords() {
+    bool doesLibHaveCoords() const {
       for (auto const &macroTemplate : d_templates) {
         if (macroTemplate->getNumConformers() == 0) {
           return false;
@@ -125,7 +123,7 @@ class RDKIT_GRAPHMOL_EXPORT MACROMolTemplateLib {
 
 class RDKIT_GRAPHMOL_EXPORT MACROMol : public RWMol {
  private:
-  // elements (MACROMolTemplate items) of the library are either owned by the library
+  // elements (MACROMolTemplate items) of the library are owned by the library
   MACROMolTemplateLib d_templateLibrary;
 
  public:
@@ -145,18 +143,14 @@ class RDKIT_GRAPHMOL_EXPORT MACROMol : public RWMol {
 
   ~MACROMol() {}
 
-  MACROMolTemplate *atomIdxToTemplatePtr(unsigned int atomIdx) const;
+  const MACROMolTemplate *getTemplate(unsigned int atomIdx) const;
 
-  MACROMolTemplateLib *getTemplateLibrary() {
-    return &d_templateLibrary;
-  }
-  
   const MACROMolTemplateLib *getTemplateLibrary() const {
     return &d_templateLibrary;
   }
 
    // the following adds a template to the internal libraty for this MACROMol
-  void addTemplate(std::unique_ptr<const MACROMolTemplate> &templateMol) {
+  void addTemplate(std::unique_ptr<MACROMolTemplate> &templateMol) {
     PRECONDITION(templateMol, "bad template molecule");
     d_templateLibrary.addTemplate(templateMol);
   }

--- a/Code/GraphMol/MACROMol.h
+++ b/Code/GraphMol/MACROMol.h
@@ -46,7 +46,7 @@ class RDKIT_GRAPHMOL_EXPORT MACROMolTemplate : public RDKit::RWMol {
   MACROMolTemplate &operator=(const MACROMolTemplate &) = delete; 
   ~MACROMolTemplate() {}
 
-  RDKit::SubstanceGroup *getMainSgroup();
+  RDKit::SubstanceGroup *getMainSgroup() const;
 
  private:
   mutable unsigned int d_mainSgroupIdx;
@@ -54,17 +54,16 @@ class RDKIT_GRAPHMOL_EXPORT MACROMolTemplate : public RDKit::RWMol {
 };
 
 
-   //! Key is (symbol, monomer_class)
-class MACROMolTemplateKey: public std::pair<std::string, std::string>{};
-
-
 class RDKIT_GRAPHMOL_EXPORT MACROMolTemplateLib {
-  
-  
-    private:
-      std::vector<std::unique_ptr<MACROMolTemplate>> d_templates;
 
-    //! Hash function for MonomerKey
+  private:
+    // All templates in the library are owned by the library and cannot be changed
+    std::vector<std::unique_ptr<const MACROMolTemplate>> d_templates;
+
+    //! Key is (monomer_class, symbol)
+    using MACROMolTemplateKey = std::pair<std::string, std::string>;
+
+    //! Hash function for MACROMolTemplateKey
     struct MACROMolTemplateKeyHash {
         std::size_t operator()(const MACROMolTemplateKey& key) const {
             std::size_t h1 = std::hash<std::string>{}(key.first);
@@ -75,9 +74,7 @@ class RDKIT_GRAPHMOL_EXPORT MACROMolTemplateLib {
 
     std::unordered_map<MACROMolTemplateKey, unsigned int, MACROMolTemplateKeyHash> d_keyToIndex;
 
-    // all templates in the library are owned by the library
-
-public:
+  public:
     MACROMolTemplateLib() = default;
     MACROMolTemplateLib(const MACROMolTemplateLib &other) = delete;
     MACROMolTemplateLib(MACROMolTemplateLib &&other) noexcept = delete;
@@ -85,61 +82,34 @@ public:
     MACROMolTemplateLib &operator=(const MACROMolTemplateLib &) = delete;  
     ~MACROMolTemplateLib() {}
 
-    std::vector<std::unique_ptr<MACROMolTemplate>>::iterator begin() {
+    std::vector<std::unique_ptr<const MACROMolTemplate>>::const_iterator begin() const {
       return d_templates.begin();
     }
-    std::vector<std::unique_ptr<MACROMolTemplate>>::iterator end() {
-      return d_templates.end();
-    }std::vector<std::unique_ptr<MACROMolTemplate>>::const_iterator begin() const{
-      return d_templates.begin();
-    }
-    std::vector<std::unique_ptr<MACROMolTemplate>>::const_iterator end() const{
+    std::vector<std::unique_ptr<const MACROMolTemplate>>::const_iterator end() const {
       return d_templates.end();
     }
 
-    void addTemplate(std::unique_ptr<MACROMolTemplate> &templateMol);
-    void addTemplateLib(MACROMolTemplateLib &libToAdd);
+    void addTemplate(std::unique_ptr<const MACROMolTemplate> &templateMol);
     void copyTemplateLib(const MACROMolTemplateLib &libToCopy);
     void clearTemplateLib(){
         d_templates.clear();
         d_keyToIndex.clear();
     }
-    void setTemplateLib(MACROMolTemplateLib &libToSet) {
-      clearTemplateLib();
-      addTemplateLib(libToSet);
-    }
 
-    unsigned int getNumTemplates(){
-      return d_templates.size();
-    }
-
-    unsigned int getNumTemplates() const { 
+    unsigned int size() const {
       return d_templates.size(); 
     }
 
-    RDKit::MACROMolTemplate *getTemplate(unsigned int index) const {
-      return d_templates.at(index).get();
-    }
-    
-    unsigned int getMACROMolTemplateIndex(std::string templateClass, std::string templateName) const {
-      MACROMolTemplateKey key(std::pair(templateClass, templateName));
-      if ( ! d_keyToIndex.contains(key)) {
-         return UINT_MAX;
-      }
-      return d_keyToIndex.at(key);
-    }
-
-    RDKit::MACROMolTemplate *getTemplate(std::string templateClass, std::string templateName) const {
-      auto index = getMACROMolTemplateIndex(templateClass, templateName);
-      if (index == UINT_MAX) {
+    const RDKit::MACROMolTemplate* find(const std::string& templateClass, const std::string& templateName) const {
+      auto iter = d_keyToIndex.find({templateClass, templateName}); 
+      if (iter == d_keyToIndex.end()) {
         return nullptr;
       }
-      return d_templates.at(index).get();
+      return d_templates.at(iter->second).get();
     }
 
-    bool libContains(std::string templateClass, std::string templateName) const {
-      MACROMolTemplateKey key(std::pair(templateClass, templateName));
-      return d_keyToIndex.contains(key);
+    bool contains(const std::string& templateClass, const std::string& templateName) const {
+      return d_keyToIndex.contains({templateClass, templateName});
     }
 
     bool doesLibHaveCoords() {
@@ -155,22 +125,12 @@ public:
 
 class RDKIT_GRAPHMOL_EXPORT MACROMol : public RWMol {
  private:
-  // elements (MACROMolTemplate items) of the library are either owned by the library or owned externally.
-  // Externally owned items support global libraies
-
+  // elements (MACROMolTemplate items) of the library are either owned by the library
   MACROMolTemplateLib d_templateLibrary;
 
-  std::vector<const MACROMolTemplateLib *> d_externalTemplateLibs;
-
-  mutable bool d_atomIdxToTemplatePtrIsStale;
-  mutable std::map<unsigned int, MACROMolTemplate *> d_atomIdxToTemplatePtr;
-
  public:
-  MACROMol() : d_atomIdxToTemplatePtrIsStale(true) {};
-  MACROMol(const MACROMol &other) : RWMol((RWMol) other), d_atomIdxToTemplatePtrIsStale(true){
-    for (const auto templateLib : other.d_externalTemplateLibs) {
-      this->d_externalTemplateLibs.push_back(templateLib);
-    }
+  MACROMol() = default;
+  MACROMol(const MACROMol &other) : RWMol((RWMol) other) {
     d_templateLibrary.copyTemplateLib(*other.getTemplateLibrary());
   }
   MACROMol(MACROMol &&other) noexcept = delete;
@@ -179,7 +139,7 @@ class RDKIT_GRAPHMOL_EXPORT MACROMol : public RWMol {
   MACROMol &operator=(const MACROMol &) = delete;  // disable assignment
 
   MACROMol(std::unique_ptr<RWMol> &rwMol)
-      : RWMol(std::move(*(rwMol))), d_atomIdxToTemplatePtrIsStale(true) {
+      : RWMol(std::move(*(rwMol))) {
     rwMol = nullptr;
   }
 
@@ -190,35 +150,18 @@ class RDKIT_GRAPHMOL_EXPORT MACROMol : public RWMol {
   MACROMolTemplateLib *getTemplateLibrary() {
     return &d_templateLibrary;
   }
-    const MACROMolTemplateLib *getTemplateLibrary() const {
+  
+  const MACROMolTemplateLib *getTemplateLibrary() const {
     return &d_templateLibrary;
   }
 
-  void clearTemplateLibrary() {
-    d_templateLibrary.clearTemplateLib();
-  }
-
-  void clearExternalTemplateLibraries() {
-    d_externalTemplateLibs.clear();
-  }
-
-  void addTemplateLibrary(const MACROMolTemplateLib *lib) {
-   d_externalTemplateLibs.push_back(lib);
-  }
-
-
    // the following adds a template to the internal libraty for this MACROMol
-  void addTemplate(std::unique_ptr<MACROMolTemplate> &templateMol) {
+  void addTemplate(std::unique_ptr<const MACROMolTemplate> &templateMol) {
     PRECONDITION(templateMol, "bad template molecule");
     d_templateLibrary.addTemplate(templateMol);
   }
 
-  unsigned int getNumTemplates() const { return d_templateLibrary.getNumTemplates(); }
-
-  MACROMolTemplate *getTemplate(unsigned int idx) { return d_templateLibrary.getTemplate(idx); }
-  const MACROMolTemplate *getTemplate(unsigned int idx) const { return d_templateLibrary.getTemplate(idx); }
-
-  unsigned int getNumExternalTemplateLibs() const { return d_externalTemplateLibs.size();}
+  unsigned int size() const { return d_templateLibrary.size(); }
 
   unsigned int addMacroAtom(std::string className, std::string templateName);
 


### PR DESCRIPTION
## Summary

Just a few suggestions on `MACROMolTemplate`, `MACROMol`, and `MACROMolTemplateLib`. My main goal was to simplify some of this a bit and make sure it will be compatible with some of our work in the HELM and global monomer library land. Since it's a new addition to RDKit I also think it's worth starting with a minimal public interface and growing it as more use cases show up.

### Minor changes
- Collapsed the public/private sections into single blocks.
- Made `MACROMolTemplateKey` a `using` alias instead of inheriting from `std::pair` — I'd rather not inherit from a std container.
- Trimmed `MACROMolTemplateLib`'s public interface: moved a few things to private, renamed the lookups to `size()`/`find()`/`contains()` so they read like a normal container, and dropped the non-const `getNumTemplates`/iterators since we only need the const ones. Also removed `setTemplateLib` and `addTemplateLib` — I think those were added to work with `MonomerMol`, and I'd like to keep the surface small for now.
- Trimmed `MACROMol` too: dropped `getTemplate(idx)` (you can use the iterator instead — I want to keep the idea of "indexing" out of the interface so we can later subclass this as a shim over a sqlite DB), dropped `clearTemplateLibrary()`, and removed the non-const `getTemplateLibrary()` so templates can't be modified through it. Also renamed `atomIdxToTemplatePtr` → `getTemplate(atomIdx)`.
- Moved `updatePropertyCache(false)` into the `MACROMolTemplate` constructor instead of making callers remember to do it.
- A bit of extra `const` marking.

### Slightly bigger changes
- Dropped the support for multiple external libraries. If a `MACROMol` doesn't define a template itself, we can just fall back to the global monomer DB (Emily's working on that in a follow-up). It didn't look like the multiple-external-lib thing had a concrete use yet — if it was there to work with our code, I'd rather sort it out in that follow-up.
- Removed `d_atomIdxToTemplatePtrIsStale` and `d_atomIdxToTemplatePtr`. With the single-library lookup and `unordered_map` already being O(1) amortized, the cache felt like extra state (and a possible data race) for not much benefit.
- Made the templates immutable to anyone using the library — it only hands out `const` access. I want to avoid a template getting changed out from under another workflow, so if you actually need to change one you copy it first.

@tadhurst-cdd - apologies that I didn't split these into smaller commits so that you could review these independently and pick what you do or do not want to add to your branch.